### PR TITLE
bower.json: define dependencies' version for purescript 0.6.9.5

### DIFF
--- a/root/bower.json
+++ b/root/bower.json
@@ -15,12 +15,12 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-arrays"               : "*",
-    "purescript-maybe"                : "*",
-    "purescript-foldable-traversable" : "*"
+    "purescript-arrays"               : "0.3.7",
+    "purescript-maybe"                : "0.2.2",
+    "purescript-foldable-traversable" : "0.3.1"
   },
   "devDependencies": {
-    "purescript-math"                 : "*",
-    "purescript-quickcheck"           : "*"
+    "purescript-math"                 : "0.1.1",
+    "purescript-quickcheck"           : "0.5.2"
   }
 }


### PR DESCRIPTION
with this small change, grunt-init works for purescript stable (0.6.9.5)
